### PR TITLE
update signals for shell 3.18

### DIFF
--- a/window_buttons@biox.github.com/extension.js
+++ b/window_buttons@biox.github.com/extension.js
@@ -607,9 +607,7 @@ WindowButtons.prototype = {
 
         // for any_window_maximized we additionaly have to be aware of max/unmax
         // events.
-        this._wmSignals.push(global.window_manager.connect('maximize',
-			Lang.bind(this, this._windowChanged)));
-        this._wmSignals.push(global.window_manager.connect('unmaximize',
+        this._wmSignals.push(global.window_manager.connect('size-change',
 			Lang.bind(this, this._windowChanged)));
 
         if (showbuttons === ShowButtonsWhen.ANY_WINDOW_MAXIMIZED) {


### PR DESCRIPTION
Since gnome-shell version 3.18, there are no 'maximize' and 'unmaximize' signals any more, but only a single 'size-change' signal. This makes window-buttons fail to load with an error message about the lack of these signals as long as it is set to only modify maximized windows. 

The dash-to-dock extension also encountered this change in [commit 4eadd6eba8c2104a3b203ff86a115a1723e9b7d7](https://github.com/Haringat/dash-to-dock/commit/13df052cdc40790fa80cdfb7d312bc9baa5e57d9). I took their solution and ported it here, which works fine for me so far.