### PR TITLE
Fixed missing signal for shell 3.18

### DIFF
--- a/window_buttons@biox.github.com/extension.js
+++ b/window_buttons@biox.github.com/extension.js
@@ -609,6 +609,8 @@ WindowButtons.prototype = {
         // events.
         this._wmSignals.push(global.window_manager.connect('size-change',
 			Lang.bind(this, this._windowChanged)));
+	this._wmSignals.push(global.window_manager.connect('hide-tile-preview',
+			Lang.bind(this, this._windowChanged)));
 
         if (showbuttons === ShowButtonsWhen.ANY_WINDOW_MAXIMIZED) {
             return;


### PR DESCRIPTION
Without adding the signal 'hide-tile-preview', the extension does not detect when the window is maximized by dragging it to the top of the screen.