### PR TITLE
Shell 3.20 compatibility

### DIFF
--- a/window_buttons@biox.github.com/metadata.json
+++ b/window_buttons@biox.github.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.18"],
+  "shell-version": ["3.18", "3.20"],
   "uuid": "window_buttons@biox.github.com",
   "name": "Window Buttons",
   "description": "Add minimize, maximize and close buttons to the panel. Originally by Josiah Messiah, maintained by m.c, then danielkza. See homepage for instructions.",


### PR DESCRIPTION
The extension loads without issues and adds buttons as expected, so I request adding 3.20 to the list of supported versions.