### PR TITLE
Drop old gconf code

### DIFF
--- a/window_buttons@biox.github.com/extension.js
+++ b/window_buttons@biox.github.com/extension.js
@@ -20,7 +20,6 @@
 
 const Lang = imports.lang;
 const St = imports.gi.St;
-const GConf = imports.gi.GConf;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
@@ -69,24 +68,16 @@ function warn(msg) {
     log("WARNING [Window Buttons]: " + msg);
 }
 
-/* Get the metacity button layout.
- * On GNOME 3.2, this can be found in GCONF key
- * /apps/metacity/general/button_layout. On GNOME 3.4, the gconf key does not
- * exist and you must use org.gnome.desktop.wm.preferences button-layout.
+/* Get the button layout.
  */
 function getMetaButtonLayout() {
-    // try Gio.Settings first. Cannot query non-existant schema in 3.2 or
-    // we'll get a segfault.
     let order;
     try {
-        // the following code will *only* work in GNOME 3.4 (schema_id property
+        // the following code will *only* work in GNOME 3.4+ (schema_id property
         // is 'schema' in GNOME 3.2):
         order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string(
             'button-layout');
     } catch (err) {
-        // GNOME 3.2
-        order = GConf.Client.get_default().get_string(
-                "/apps/metacity/general/button_layout");
     }
     return order;
 }
@@ -188,7 +179,6 @@ WindowButtons.prototype = {
             try {
                 theme = Gtk.Settings.get_default().gtk_theme_name;
             } catch(err) {
-                theme = Meta.prefs_get_theme();
             }
         } else {
             theme = this._settings.get_string(WA_THEME);

--- a/window_buttons@biox.github.com/prefs.js
+++ b/window_buttons@biox.github.com/prefs.js
@@ -46,7 +46,6 @@ const WA_HIDEINOVERVIEW = 'hide-in-overview';
 // Keep enums in sync with GSettings schemas
 const PinchType = {
     CUSTOM: 0,
-    METACITY: 1,
     GNOME_SHELL: 2
 };
 
@@ -141,8 +140,7 @@ const WindowButtonsPrefsWidget = new GObject.Class({
         this._themeCombo = item;
 
         // doMetacity
-        this._doMetacity = this.addBoolean("Match Metacity theme if possible\n" +
-            " (/apps/metacity/general/theme, OVERRIDES above theme)",
+        this._doMetacity = this.addBoolean("Match theme if possible",
             WA_DO_METACITY);
         this._doMetacity.connect('notify::active', Lang.bind(this, function () {
             this._themeCombo.set_sensitive(!this._doMetacity.active);

--- a/window_buttons@biox.github.com/schemas/org.gnome.shell.extensions.window-buttons.gschema.xml
+++ b/window_buttons@biox.github.com/schemas/org.gnome.shell.extensions.window-buttons.gschema.xml
@@ -3,7 +3,6 @@
   
   <enum id='org.gnome.shell.extensions.window-buttons.PinchType'>
     <value value='0' nick='custom'/>
-    <value value='1' nick='metacity'/>
     <value value='2' nick='gnome-shell'/>
   </enum>
 
@@ -44,8 +43,8 @@
     
     <key type="b" name="do-metacity">
       <default>true</default>
-      <summary>Match Metacity theme if possible</summary>
-      <description>Try to use the theme with the same name as the current metacity theme ('/apps/metacity/general/theme')</description>
+      <summary>Match theme if possible</summary>
+      <description>Try to use the current GTK theme)</description>
     </key>
 
     <key type="b" name="hide-in-overview">


### PR DESCRIPTION
This code hasn't done anything since GNOME 3.4, which we don't
support anyway.

This is a follow up from https://launchpad.net/bugs/1592974