### PR TITLE
Updated shell version to include 3.22

### DIFF
--- a/window_buttons@biox.github.com/metadata.json
+++ b/window_buttons@biox.github.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.18", "3.20"],
+  "shell-version": ["3.18", "3.20", "3.22"],
   "uuid": "window_buttons@biox.github.com",
   "name": "Window Buttons",
   "description": "Add minimize, maximize and close buttons to the panel. Originally by Josiah Messiah, maintained by m.c, then danielkza. See homepage for instructions.",


### PR DESCRIPTION
I've tested it using same settings as my other machine running GNOME 3.20 and did not find any inconsistencies.
